### PR TITLE
Promote to prod environment

### DIFF
--- a/components/python-obvbfvfr/overlays/prod/deployment-patch.yaml
+++ b/components/python-obvbfvfr/overlays/prod/deployment-patch.yaml
@@ -12,5 +12,5 @@ spec:
   template: 
     spec:
       containers:
-      - image: quay.io/redhat-appstudio/dance-bootstrap-app:latest
+      - image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/python-obvbfvfr:github-3152f34468701f24eab80a8f6eee39fd378eabdf
         name: container-image  


### PR DESCRIPTION
This PR promotes the application to the prod environment with image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/python-obvbfvfr:github-3152f34468701f24eab80a8f6eee39fd378eabdf